### PR TITLE
fix: Fix wrong check on the `PosColumn`

### DIFF
--- a/lib/src/pos_column.dart
+++ b/lib/src/pos_column.dart
@@ -15,7 +15,7 @@ class PosColumn {
     if (width < 1 || width > 12) {
       throw Exception('Column width must be between 1..12');
     }
-    if (text.isEmpty && textEncoded != null && textEncoded!.isNotEmpty) {
+    if (text.isNotEmpty && textEncoded != null && textEncoded!.isNotEmpty) {
       throw Exception(
           'Only one parameter - text or textEncoded - should be passed');
     }


### PR DESCRIPTION
**Description**: The `PosColumn` class throws the below exception for the correct parameter due to an incorrect check inside the contractor. The PR fixes it by reverting the check on one of the fields.


```
E/flutter ( 5924): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Exception: Only one parameter - text or textEncoded - should be passed
E/flutter ( 5924): #0      new PosColumn (package:flutter_esc_pos_utils/src/pos_column.dart:19:7)
E/flutter ( 5924): #1      Generator.row (package:flutter_esc_pos_utils/src/generator.dart:502:25)
``` 